### PR TITLE
UNOWIFIDEVED setup pin 4 HIGH

### DIFF
--- a/ArduinoFirmwareEsp/ArduinoFirmwareEsp.ino
+++ b/ArduinoFirmwareEsp/ArduinoFirmwareEsp.ino
@@ -20,6 +20,11 @@ ESP8266WebServer server(80);    //server UI
 
 void setup() {
 
+#if defined(UNOWIFIDEVED)
+  pinMode(4, OUTPUT);
+  digitalWrite(4, 1);
+#endif
+  
   pinMode(WIFI_LED, OUTPUT);      //initialize wifi LED
   digitalWrite(WIFI_LED, LOW);
   ArduinoOTA.begin();             //OTA ESP


### PR DESCRIPTION
it is necessary in setup() to set pin 4 high for UNOWIFIDEVED for Atmel <-> ESP communication over SC16IS750. Sometimes the pin doesn't float high enough.